### PR TITLE
Restrict repo access to collaborators only for public visibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Require approval from the repository owner for all changes.
+# When this repo is public, any outside contributor's PR must be
+# reviewed and approved by a code owner before it can be merged.
+
+* @MaxxoRelaxxo

--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   # Cancel in-progress deploys to same branch
   group: ${{ github.ref }}/branch_deployments
@@ -18,6 +22,8 @@ jobs:
   dagster_cloud_default_deploy:
     name: Dagster Serverless Deploy
     runs-on: ubuntu-22.04
+    # Only run for PRs from branches in this repo, not from forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
 
@@ -53,7 +59,9 @@ jobs:
   dagster_cloud_docker_deploy:
     name: Docker Deploy
     runs-on: ubuntu-22.04
-    if: needs.dagster_cloud_default_deploy.outputs.build_info
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.dagster_cloud_default_deploy.outputs.build_info
     needs: dagster_cloud_default_deploy
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
       - "main"
       - "master"
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel in-progress deploys to same branch
   group: ${{ github.ref }}/deploy


### PR DESCRIPTION
- Add CODEOWNERS file requiring @MaxxoRelaxxo approval on all changes
- Block fork PRs from triggering Dagster branch deployments
- Scope workflow GITHUB_TOKEN permissions to least privilege (read-only)

https://claude.ai/code/session_0119UyG5FWZXyT5ttwRjP8gQ