### PR TITLE
Fix certificate data filtering and improve rate synchronization

### DIFF
--- a/frontend/src/components/CertificateSection.jsx
+++ b/frontend/src/components/CertificateSection.jsx
@@ -37,7 +37,7 @@ export default function CertificateSection() {
 
   const chartData = timeseries.slice(-120).map((d) => ({
     date: d.date.slice(0, 7),
-    "Erbjuden volym": d.erbjuden_volym,
+    "Tilldelad volym": d.tilldelad_volym,
     "Likviditetsöverskott": d.aterstaende,
     "Räntefri inlåning": d.rantefri_inlaning,
   }));
@@ -53,7 +53,7 @@ export default function CertificateSection() {
       <div className="stat-row">
         <StatCard label="Erbjuden volym" value={fmt(l.erbjuden_volym)} unit="mdkr" delta={l.delta_erbjuden} />
         <StatCard label="Tilldelad volym" value={fmt(l.tilldelad_volym)} unit="mdkr" delta={l.delta_tilldelad} />
-        <StatCard label="Aterstande overskott" value={fmt(l.aterstaende)} unit="mdkr" delta={l.delta_aterstaende} />
+        <StatCard label="Återstående likviditetsöverskott" value={fmt(l.aterstaende)} unit="mdkr" delta={l.delta_aterstaende} />
         <StatCard label="Antal bud" value={String(l.antal_bud)} delta={l.delta_antal_bud} />
       </div>
 
@@ -72,7 +72,7 @@ export default function CertificateSection() {
             />
             <Tooltip content={<ChartTooltip />} />
             <Legend wrapperStyle={{ fontSize: 12, paddingTop: 12 }} />
-            <Bar dataKey="Erbjuden volym" stackId="stack" fill="#0071B9" fillOpacity={0.85} />
+            <Bar dataKey="Tilldelad volym" stackId="stack" fill="#0071B9" fillOpacity={0.85} />
             <Bar dataKey="Likviditetsöverskott" stackId="stack" fill="#B91E2B" fillOpacity={0.85} />
             <Bar dataKey="Räntefri inlåning" stackId="stack" fill="#D4880A" fillOpacity={0.85} radius={[3, 3, 0, 0]} />
           </BarChart>

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -28,6 +28,7 @@ def _dump(obj, name):
 def build_cert():
     df = (
         pl.read_parquet(DATA_DIR / "rb_cert_auctions_result.parquet")
+        .filter(pl.col("Anbudsdag").dt.year() <= date.today().year)
         .sort("Anbudsdag")
         .with_columns(
             (pl.col("Erbjuden_volym") - pl.col("Tilldelad_volym"))
@@ -79,6 +80,7 @@ def build_cert():
             {
                 "date": d.isoformat() if isinstance(d, date) else str(d),
                 "erbjuden_volym": r["Erbjuden_volym"],
+                "tilldelad_volym": r["Tilldelad_volym"],
                 "aterstaende": r["Aterstaende"],
                 "rantefri_inlaning": ri,
             }
@@ -155,10 +157,11 @@ def build_swestr():
     )
     df = (
         df_swestr.filter(~pl.col("date").is_in(cut["last_dec"].implode()))
-        .join(df_policy, on="date")
+        .join(df_policy, on="date", how="left")
         .rename({"value": "policy_rate"})
-        .with_columns((pl.col("rate") - pl.col("policy_rate")).round(4).alias("diff"))
         .sort("date")
+        .with_columns(pl.col("policy_rate").forward_fill())
+        .with_columns((pl.col("rate") - pl.col("policy_rate")).round(4).alias("diff"))
     )
 
     last = df.tail(1).row(0, named=True)
@@ -237,7 +240,8 @@ def build_scb_rates():
         .select(["Rantebindningstid", "Tid", "value"])
         .with_columns(
             pl.col("Tid").str.replace("M", "-").str.to_date("%Y-%m"),
-            pl.col("Rantebindningstid").str.replace(r"^\d+\s*", ""),
+            pl.col("Rantebindningstid").str.replace(r"^\d+\s*", "")
+            .str.replace("Med villkor", "Inlåning med villkor"),
         )
         .rename({"Tid": "date", "Rantebindningstid": "rate"})
     )
@@ -251,8 +255,14 @@ def build_scb_rates():
         .with_columns(pl.lit("Styrränta").alias("rate"))
         .select(["rate", "date", "value"])
     )
+    # Sync all series to the same max date (use the earliest max date across non-policy series)
+    max_mortgage = df_mortgage["date"].max()
+    max_deposit = df_deposit["date"].max()
+    max_date = min(max_mortgage, max_deposit)
+
     df_rates = pl.concat([df_rates, df_mortgage, df_deposit]).filter(
-        pl.col("date") >= date(2006, 1, 1)
+        (pl.col("date") >= date(2006, 1, 1))
+        & (pl.col("date") <= max_date)
     )
 
     household_rates = [


### PR DESCRIPTION
## Summary
This PR fixes data filtering issues in certificate auctions and improves the synchronization of interest rate series across different data sources. It also updates the certificate section UI to display allocated volume instead of offered volume.

## Key Changes

**Certificate Data (`build_cert`)**
- Added filter to exclude future auction dates (only include auctions up to current year)
- Added `tilldelad_volym` (allocated volume) to the exported data structure
- Updated frontend to display allocated volume in charts and statistics instead of offered volume
- Improved label clarity for remaining liquidity surplus

**Interest Rate Synchronization (`build_swestr` and `build_scb_rates`)**
- Changed policy rate join from inner to left join to preserve all SWESTR dates
- Added forward fill for policy rate to handle missing values
- Reordered operations to apply forward fill before calculating rate differences
- Added synchronization logic to align mortgage and deposit rate series to the earliest maximum date across non-policy series
- Fixed string replacement for deposit rate categories to properly map "Med villkor" to "Inlåning med villkor"
- Added explicit date range filter (2006-01-01 onwards) with upper bound constraint

**Frontend Updates (`CertificateSection.jsx`)**
- Changed chart data key from "Erbjuden volym" to "Tilldelad volym"
- Updated bar chart to display allocated volume instead of offered volume
- Improved label text for remaining liquidity surplus ("Återstående likviditetsöverskott")

## Notable Implementation Details
- The rate synchronization uses `min()` across max dates to ensure all series end at the same point, preventing misalignment in downstream analysis
- Forward fill for policy rates ensures continuous data for rate difference calculations even when policy rate updates are sparse

https://claude.ai/code/session_01DpqJkjoMCQc8cRCQpRycpf