### PR TITLE
Improve chart date formatting and tick display consistency

### DIFF
--- a/frontend/src/components/CertificateSection.jsx
+++ b/frontend/src/components/CertificateSection.jsx
@@ -36,7 +36,7 @@ export default function CertificateSection() {
   const { latest: l, timeseries } = data;
 
   const chartData = timeseries.slice(-120).map((d) => ({
-    date: d.date.slice(0, 7),
+    date: d.date,
     "Tilldelad volym": d.tilldelad_volym,
     "Likviditetsöverskott": d.aterstaende,
     "Räntefri inlåning": d.rantefri_inlaning,

--- a/frontend/src/components/ScbRatesSection.jsx
+++ b/frontend/src/components/ScbRatesSection.jsx
@@ -88,7 +88,7 @@ function HouseholdChart({ data }) {
           <CartesianGrid strokeDasharray="3 3" stroke="var(--grid-line)" />
           <XAxis
             dataKey="date"
-            tickFormatter={(d) => d.slice(0, 4)}
+            tickFormatter={(d) => d.slice(0, 7)}
             interval={Math.max(1, Math.floor(pivoted.length / 10))}
             tick={{ fontSize: 10, fill: "var(--muted)" }}
             tickLine={false}
@@ -170,7 +170,7 @@ function NfcChart({ data }) {
           <CartesianGrid strokeDasharray="3 3" stroke="var(--grid-line)" />
           <XAxis
             dataKey="date"
-            tickFormatter={(d) => d.slice(0, 4)}
+            tickFormatter={(d) => d.slice(0, 7)}
             interval={Math.max(1, Math.floor(pivoted.length / 8))}
             tick={{ fontSize: 10, fill: "var(--muted)" }}
             tickLine={false}
@@ -238,7 +238,7 @@ function BrfChart({ data }) {
           <CartesianGrid strokeDasharray="3 3" stroke="var(--grid-line)" />
           <XAxis
             dataKey="date"
-            tickFormatter={(d) => d.slice(0, 4)}
+            tickFormatter={(d) => d.slice(0, 7)}
             interval={Math.max(1, Math.floor(pivoted.length / 10))}
             tick={{ fontSize: 10, fill: "var(--muted)" }}
             tickLine={false}

--- a/frontend/src/components/SwestrSection.jsx
+++ b/frontend/src/components/SwestrSection.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   ComposedChart, Line, Area, AreaChart, XAxis, YAxis, Tooltip, CartesianGrid,
   ReferenceLine, ResponsiveContainer, Legend,
@@ -36,6 +36,14 @@ export default function SwestrSection() {
 
   const last = timeseries[timeseries.length - 1];
   const prev = timeseries.length > 1 ? timeseries[timeseries.length - 2] : null;
+
+  const swestrTicks = useMemo(() => {
+    const dates = timeseries.map((d) => d.date);
+    const result = dates.filter((_, i) => i % 120 === 0);
+    const lastDate = dates[dates.length - 1];
+    if (result[result.length - 1] !== lastDate) result.push(lastDate);
+    return result;
+  }, [timeseries]);
 
   return (
     <div>
@@ -90,7 +98,7 @@ export default function SwestrSection() {
               </defs>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--grid-line)" />
               <XAxis
-                dataKey="date" interval={120}
+                dataKey="date" ticks={swestrTicks}
                 tick={{ fontSize: 10, fill: "var(--muted)" }} tickLine={false} axisLine={false}
               />
               <YAxis
@@ -173,7 +181,7 @@ export default function SwestrSection() {
               </defs>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--grid-line)" />
               <XAxis
-                dataKey="date" interval={120}
+                dataKey="date" ticks={swestrTicks}
                 tick={{ fontSize: 10, fill: "var(--muted)" }} tickLine={false} axisLine={false}
               />
               <YAxis


### PR DESCRIPTION
## Summary
This PR improves the date display and tick handling across multiple chart components to provide better readability and consistency. The changes focus on displaying dates in YYYY-MM format instead of just the year, and implementing smarter tick selection logic.

## Key Changes

- **SwestrSection**: Replaced the `interval={120}` approach with a `useMemo`-based `swestrTicks` calculation that intelligently selects tick positions (every 120 data points) while always including the last date for better data context
- **ScbRatesSection**: Updated date formatting in three chart components (HouseholdChart, NfcChart, BrfChart) from `slice(0, 4)` (year only) to `slice(0, 7)` (YYYY-MM format) for improved readability
- **CertificateSection**: Removed unnecessary date slicing to preserve full date format in the chart data

## Implementation Details

The `swestrTicks` memoization in SwestrSection ensures that:
- Tick positions are calculated once and only recalculated when the timeseries data changes
- The last date is always included as a tick, even if it doesn't fall on a 120-interval boundary
- This provides better visual anchoring for users viewing the chart

The date formatting changes across ScbRatesSection provide month-level granularity instead of year-only, making it easier to identify specific time periods in the data.

https://claude.ai/code/session_01CaoRiELVWne4hHUsKBdLLK